### PR TITLE
Fix SegmentException not found

### DIFF
--- a/src/Segment.php
+++ b/src/Segment.php
@@ -3,6 +3,8 @@
 namespace Odtphp;
 
 use Odtphp\SegmentIterator;
+use Odtphp\Exceptions\SegmentException;
+use Odtphp\Exceptions\OdfException;
 
 /**
  * Class for handling templating segments with odt files


### PR DESCRIPTION
Fixes:

<pre>
Uncaught Exception Error: Class 'Odtphp\SegmentException' not found in /var/www/html/glpi/plugins/order/vendor/masnathan/odtphp/src/Segment.php at line 156
  Backtrace :
  plugins/order/inc/order.class.php:1865             Odtphp\Segment->setVars()
  plugins/order/front/export.php:34                  PluginOrderOrder->generateOrder()
</pre>

(and also "OdfException not found")