### PR TITLE
Fix RegExp too greedy in function setSegment

### DIFF
--- a/src/Odf.php
+++ b/src/Odf.php
@@ -257,7 +257,7 @@ IMG;
             return $this->segments[$segment];
         }
         // $reg = "#\[!--\sBEGIN\s$segment\s--\]<\/text:p>(.*?)<text:p\s.*>\[!--\sEND\s$segment\s--\]#sm";
-        $reg = "#\[!--\sBEGIN\s$segment\s--\](.*?)\[!--\sEND\s$segment\s--\]#smU";
+        $reg = "#\[!--\sBEGIN\s$segment\s--\](.*)\[!--\sEND\s$segment\s--\]#smU";
         if (preg_match($reg, html_entity_decode($this->contentXml), $m) == 0) {
             throw new OdfException("'$segment' segment not found in the document");
         }


### PR DESCRIPTION
If you have multiple segments with the same name in your odt, the RegExp in function setSegment matches all of them at once. The RegExp shoud be lazy.